### PR TITLE
Remove obsolete #pragma since we specify a full manifest

### DIFF
--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -62,9 +62,6 @@ BEGIN_MESSAGE_MAP(CFamiTrackerApp, CWinApp)
 	ON_UPDATE_COMMAND_UI(ID_FILE_MRU_FILE1, OnUpdateRecentFiles)		// // //
 END_MESSAGE_MAP()
 
-// Include this for windows xp style in visual studio 2005 or later
-#pragma comment(linker, "\"/manifestdependency:type='Win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='X86' publicKeyToken='6595b64144ccf1df' language='*'\"")
-
 // CFamiTrackerApp construction
 
 CFamiTrackerApp::CFamiTrackerApp() :


### PR DESCRIPTION
In CMake, regenerating the manifest takes a clean rebuild. In CMake, the resulting binary works. Let's check if it works on msbuild.

i don't care anymore. just merge it instead of letting it languish for months.