### PR TITLE
Fix out-of-bounds read with N163 periods over 0x80

### DIFF
--- a/Source/SeqInstHandlerN163.cpp
+++ b/Source/SeqInstHandlerN163.cpp
@@ -85,7 +85,7 @@ void CSeqInstHandlerN163::UpdateWave(const CInstrumentN163 *pInst)
 	// raw position and count
 	// int Duty = m_pInterface->GetDutyPeriod();
 	// if (Duty < 0) return;
-	int Index = m_pInterface->GetDutyPeriod();
+	int Index = m_pInterface->GetDutyPeriod() & 0xFF;
 	if (Index >= pInst->GetWaveCount())
 		Index = pInst->GetWaveCount() - 1;
 	const int Count = pInst->GetWaveSize() >> 1;


### PR DESCRIPTION
Previously, on N163, V80 and above were treated as negative wave indices and read out-of-bounds memory, which sometimes crashed.

Fixes #163.